### PR TITLE
Fix sensitivity matrix dimensions

### DIFF
--- a/mlem/mlem_reconstruct.py
+++ b/mlem/mlem_reconstruct.py
@@ -31,6 +31,10 @@ class MLEMReconstructor:
         | ``...``
         | ``(x0,yN,zN), (x1,yN,zN) ... (xN,yN,zN)``
 
+    To ensure the correct size of the sensitivity matrix, the class has to be
+    initialized with the values of img_nvoxels_xy and img_nvoxels_z in the
+    constructor method.
+
     **NOTE:** the LOR points may need to be sorted for the reconstruction to
     be correct
 

--- a/mlem/mlem_reconstruct.py
+++ b/mlem/mlem_reconstruct.py
@@ -59,7 +59,7 @@ class MLEMReconstructor:
         self.prefix = prefix
         self.niterations = niterations
         self.save_every = save_every
-        self.TOF = True
+        self.TOF = TOF
         self.TOF_resolution = TOF_resolution
         self.img_size_xy = img_size_xy
         self.img_size_z = img_size_z


### PR DESCRIPTION
This PR fixes the way the sensitivity matrix dimensions were set in case `self.smatrix = None`. It depends on the variables `self.img_nvoxels_xy` and `self.img_nvoxels_z` and it was set in the `__init__` of the class, but if these variables were changed by the user, `self.smatrix` didn't change. This has been fixed as well as the default value for `self.TOF`.